### PR TITLE
Don't enable the optimize parameters option

### DIFF
--- a/src/com/google/javascript/jscomp/CompilationLevel.java
+++ b/src/com/google/javascript/jscomp/CompilationLevel.java
@@ -305,7 +305,7 @@ public enum CompilationLevel {
 
     // Call optimizations
     options.devirtualizePrototypeMethods = true;
-    options.optimizeParameters = true;
+    options.optimizeParameters = false;
     options.optimizeReturns = true;
 
     // The following optimizations break Shumway builds and need further investigation:


### PR DESCRIPTION
Since we're optimizing j2me.js, classes.jar.js and the other JS files separately, we can't enable this option.
If enabled, functions in j2me.js could have a different set of parameters than what the other JS code expects.